### PR TITLE
Update XMB_IT.TXT

### DIFF
--- a/extras/xmbctrl/translations/XMB_IT.TXT
+++ b/extras/xmbctrl/translations/XMB_IT.TXT
@@ -8,6 +8,6 @@ Disattiva pausa su PSP Go
 Forza memoria aggiuntiva
 Velocizza memory stick
 Cache di Inferno
-Supporto plugin obsoleti su PSP Go
+Correggi incompatibilità plugin su PSP Go
 Salta loghi di Sony
 Nascondi PIC0 e PIC1

--- a/extras/xmbctrl/translations/XMB_IT.TXT
+++ b/extras/xmbctrl/translations/XMB_IT.TXT
@@ -1,13 +1,13 @@
-Configurazione di Custom Firmware
-Amministratore di Plugins
+Configurazione custom firmware
+Gestione plugin
 Ricarica USB
 Overclock
 Risparmio energetico
-Caricamento automatico di menu personalizzato
-Disabilita la funzione di pausa su PSP Go
+Avvio automatico launcher
+Disattiva pausa su PSP Go
 Forza memoria aggiuntiva
-Accelerazione di Memory Stick
+Velocizza memory stick
 Cache di Inferno
-Correggi gli plugins classici su PSP Go
-Saltare gli logos di Sony
-Nascondere PIC0 e PIC1
+Supporto plugin obsoleti su PSP Go
+Salta loghi di Sony
+Nascondi PIC0 e PIC1


### PR DESCRIPTION
Fix Italian translations

Some remarks: in Italian capital letters are only used with first names, surnames, city names, and so on, which is why I've removed them. I've also deleted articles (like ‘the’ in English) and prepositions (like “of, by, from” in English), not only because there is none in the English version but also because it doesn't feel very natural to have them in a settings menu. Lastly, I think the word ‘launcher’ does not need any translation and/or there is no good way to translate it along with the word ‘autoboot’; I've considered a few alternatives but simply using ‘launcher’ sounds much better. Might be my Computer Science background talking though