### PR TITLE
Adds Text Based Battery Percent Setting To Custom Launcher

### DIFF
--- a/extras/menus/arkMenu/include/conf.h
+++ b/extras/menus/arkMenu/include/conf.h
@@ -24,6 +24,7 @@ typedef struct {
     unsigned char vsh_bg_color; // Advanced VSH Menu Background color
     unsigned char swap_xo; // Advanced VSH Menu swap X/O buttons
     unsigned char force_update; // Force update (disable update version check)
+    unsigned char battery_percent; // show remaing battery percent next to battery icon
 } t_conf;
 
 #endif

--- a/extras/menus/arkMenu/include/settings_entries.h
+++ b/extras/menus/arkMenu/include/settings_entries.h
@@ -251,6 +251,20 @@ static struct {
     {"Disabled", "Enabled"}
 };
 
+static struct {
+    char* description;
+    unsigned char max_options;
+    unsigned char selection;
+    unsigned char* config_ptr;
+    char* options[2];
+} battery_percent = {
+    "Display Battery Percent",
+    2,
+    0,
+    &(common::getConf()->battery_percent),
+    {"Disabled", "Enabled"}
+};
+
 settings_entry* settings_entries[] = {
     (settings_entry*)&fast_gameboot,
     (settings_entry*)&language,
@@ -268,6 +282,7 @@ settings_entry* settings_entries[] = {
     (settings_entry*)&screensaver,
     (settings_entry*)&redirect_ms0,
     (settings_entry*)&force_update,
+    (settings_entry*)&battery_percent,
 };
 
 #define MAX_SETTINGS_OPTIONS (sizeof(settings_entries)/sizeof(settings_entries[0]))

--- a/extras/menus/arkMenu/src/system_mgr.cpp
+++ b/extras/menus/arkMenu/src/system_mgr.cpp
@@ -163,7 +163,7 @@ static void dateTime() {
 
 	char dateStr[100];
 	sprintf(dateStr, "%04d/%02d/%02d %02d:%02d:%02d", date.year, date.month, date.day, date.hour, date.minutes, date.seconds);
-    common::printText(300, 13, dateStr, LITEGRAY, SIZE_MEDIUM, 0, 0);
+    (common::getConf()->battery_percent) ? common::printText(270, 13, dateStr, LITEGRAY, SIZE_MEDIUM, 0, 0) : common::printText(300, 13, dateStr, LITEGRAY, SIZE_MEDIUM, 0, 0);
 }
 
 static void drawBattery(){
@@ -186,6 +186,12 @@ static void drawBattery(){
                 color = LITEGRAY;
             else
                 color = RED;
+        }
+
+        if (common::getConf()->battery_percent) {
+        char batteryPercent[4];
+        sprintf(batteryPercent, "%d%%", percent);
+        common::printText(415, 13, batteryPercent, color, SIZE_MEDIUM, 0, 0);
         }
 
         ya2d_draw_rect(455, 6, 20, 8, color, 0);


### PR DESCRIPTION
Battery text will be the same colour as the battery bar
Moves the Date/Time to make space for the battery text only when Enabled