### PR TITLE
Enable Img for iso disc extension

### DIFF
--- a/core/vshctrl/virtual_pbp.c
+++ b/core/vshctrl/virtual_pbp.c
@@ -170,6 +170,7 @@ static int is_iso(SceIoDirent * dir)
         //check extension
         if (
                 stricmp(ext, ".iso") == 0 ||
+                stricmp(ext, ".img") == 0 ||
                 stricmp(ext, ".cso") == 0 ||
                 stricmp(ext, ".zso") == 0 ||
                 stricmp(ext, ".dax") == 0 ||

--- a/extras/menus/arkMenu/src/iso.cpp
+++ b/extras/menus/arkMenu/src/iso.cpp
@@ -325,6 +325,7 @@ bool Iso::isISO(const char* filename){
     string ext = common::getExtension(filename);
     return (
         ext == "iso" ||
+        ext == "img" ||
         ext == "cso" ||
         ext == "zso" ||
         ext == "jso" ||


### PR DESCRIPTION
I have a collection of PSP games that are just iso's with extension img, I rather keep as is.