### PR TITLE
update remaining extension references for consistency

### DIFF
--- a/extras/menus/advancedvsh/umdvideo_list.c
+++ b/extras/menus/advancedvsh/umdvideo_list.c
@@ -156,7 +156,7 @@ int get_umdvideo(UmdVideoList *list, char *path) {
 		if (p == NULL)
 			p = dir.d_name;
 
-		if (0 == stricmp(p, ".iso") || 0 == stricmp(p, ".cso") || 0 == stricmp(p, ".zso") || 0 == stricmp(p, ".dax") || 0 == stricmp(p, ".jso")) {
+		if (0 == stricmp(p, ".iso") || 0 == stricmp(p, ".img") || 0 == stricmp(p, ".cso") || 0 == stricmp(p, ".zso") || 0 == stricmp(p, ".dax") || 0 == stricmp(p, ".jso")) {
 			scePaf_sprintf(fullpath, "%s/%s", path, dir.d_name);
 			umdvideolist_add(list, fullpath);
 		}

--- a/extras/menus/recovery_classic/proshell.c
+++ b/extras/menus/recovery_classic/proshell.c
@@ -516,7 +516,7 @@ int isGameISO(const char * path)
 {
     const char *ext;
     const char* known[] = {
-        ".iso", ".cso", ".zso", ".jso", ".dax"
+        ".iso", ".img", ".cso", ".zso", ".jso", ".dax"
     };
 
     ext = path + strlen(path) - 4;


### PR DESCRIPTION
Just a small follow up to to https://github.com/PSP-Archive/ARK-4/pull/206

as noted in the previous PR dont have any video UMD, nor do I know where is `proshell.c` usecase is, but these edits should be mostly cosmetic, as the underlaying file format should be an iso.