### PR TITLE
Fixed CL System Menu Margins and Removed Hardcoded Offsets

### DIFF
--- a/extras/menus/arkMenu/src/system_mgr.cpp
+++ b/extras/menus/arkMenu/src/system_mgr.cpp
@@ -234,8 +234,8 @@ static void drawDateTime() {
     pspTime date;
     sceRtcGetCurrentClockLocalTime(&date);
 
-    char dateStr[100];
-    sprintf(dateStr, "%04d/%02d/%02d %02d:%02d:%02d", date.year, date.month, date.day, date.hour, date.minutes, date.seconds);
+    char dateStr[20];
+    snprintf(dateStr, 20, "%04d/%02d/%02d %02d:%02d:%02d", date.year, date.month, date.day, date.hour, date.minutes, date.seconds);
     int x = 445 - common::calcTextWidth(dateStr, SIZE_MEDIUM, 0);
     if (common::getConf()->battery_percent) x -= common::calcTextWidth("-100%", SIZE_MEDIUM, 0);
     common::printText(x, 13, dateStr, LITEGRAY, SIZE_MEDIUM, 0, 0, 0);


### PR DESCRIPTION
This PR:
- Removes all hardcoded position offsets from the System Menu (text positioning should be consistent across all languages and fonts).
- Fixes margins for menu icons. Previously, small had like 4 and a half icons visible, now it has 5. I updated the paging functionality to account for this. Additionally, margins regarding the beginning and end of system entry icons are now consistent and relative to menu size.
- Some miscellaneous adjustments like dead code removal and enforcing snprintf.

Overall, this is a QOL update and should make the ARK user experience better, especially for those who use languages other than English. Any additions to the menu should now be seamless with this PR. 