### PR TITLE
CL Volume Indicator and Some Minor ya2d Optimizations

### DIFF
--- a/extras/menus/arkMenu/include/controller.h
+++ b/extras/menus/arkMenu/include/controller.h
@@ -10,8 +10,11 @@ class Controller{
         SceCtrlData pad;
         
         u32 nowpad, newpad, oldpad;
-        
         int n;
+
+        void *_ksceCtrlReadBufferPositive;
+
+        void clCtrlReadBufferPositive();
     
     public:
     
@@ -25,6 +28,9 @@ class Controller{
         
         // generic wait for user input, returns true if cross pressed, false if circle is pressed
         bool wait(void* busy_wait=NULL);
+
+        // Return the current pad data
+        u32 get_buttons();
         
         // check for accept or decline from user (depending on the button configuration)
         bool any();
@@ -45,6 +51,7 @@ class Controller{
         bool start();
         bool select();
         bool home();
+        bool volume();
 };
         
 

--- a/extras/menus/arkMenu/src/ya2d++.cpp
+++ b/extras/menus/arkMenu/src/ya2d++.cpp
@@ -9,7 +9,6 @@ Image::Image(){
 Image::Image(ya2d_texture* tex){
     this->texture = tex;
     this->is_system_image = false;
-    flush();
 }
 
 Image::Image(string filename, int place){
@@ -24,7 +23,6 @@ Image::Image(string filename, int place){
     else if (ext == "bmp"){
         this->texture = ya2d_load_BMP_file(filename.c_str(), place);
     }
-    flush();
 }
 
 Image::Image(void* buffer, int place){
@@ -34,20 +32,17 @@ Image::Image(void* buffer, int place){
         this->texture = ya2d_load_PNG_buffer(buffer, place);
     else if (magic == BMP_MAGIC)
         this->texture = ya2d_load_BMP_buffer(buffer, place);
-    flush();
 }
 
 Image::Image(void* buffer, unsigned long buffer_size, int place){
     this->is_system_image = false;
     if ( (*(u32*)buffer & 0x0000FFFF) == JPG_MAGIC)
         this->texture = ya2d_load_JPEG_buffer(buffer, buffer_size, place);
-    flush();
 }
 
 Image::Image(string filename, int place, SceOff offset){
     this->is_system_image = false;
     this->texture = ya2d_load_PNG_file_offset(filename.c_str(), place, offset);
-    flush();
 }
 
 Image::~Image(){


### PR DESCRIPTION
This PR adds:

- A volume indicator in the custom launcher (complete with many work-arounds, thanks Sony!)
- Minor optimizations in CL's ya2d++ by removing redundant dcache writebacks.


https://github.com/user-attachments/assets/bf614634-66ad-4b2d-91db-b8dab8131f07

