### PR TITLE
Spoof version for osk_plugin

### DIFF
--- a/core/systemctrl/src/syspatch.c
+++ b/core/systemctrl/src/syspatch.c
@@ -155,7 +155,7 @@ static void ARKSyspatchOnModuleStart(SceModule2 * mod)
     }
 
     // unlocks variable bitrate on old homebrew
-    if (strcmp(mod->modname, "sceMp3_Library") == 0){
+    if (strcmp(mod->modname, "sceMp3_Library") == 0 || strcmp(mod->modname, "sceVshOSK_Module") == 0){
         hookImportByNID(mod, "SysMemUserForUser", 0xFC114573, &sctrlHENFakeDevkitVersion);
         goto flush;
     }


### PR DESCRIPTION
Enables QWERTY layout on (hopefully) all software, tested on Custom Launcher and LittleBigPlanet which both do not support QWERTY on stock, but do with this patch. Thanks to @JoseAaronLopezGarcia for helping!
Resolves issue #409 