### PR TITLE
New CFW settings exception for `Assassin's Creed: Bloodlines`

### DIFF
--- a/contrib/SETTINGS.TXT
+++ b/contrib/SETTINGS.TXT
@@ -22,3 +22,6 @@ ULUS10201, infernocache, off
 
 # Enable Extra RAM on GTA LCS and VCS
 ULUS10041 ULUS10160 ULES00151 ULES00502, highmem, on
+
+# AC Bloodlines crashes with extra RAM
+ULES01367, highmem, off

--- a/extras/menus/arkMenu/include/ark_settings.h
+++ b/extras/menus/arkMenu/include/ark_settings.h
@@ -858,8 +858,6 @@ void resetSettings() {
     custom_config.push_back("ULUS10201, infernocache, off\n");
     custom_config.push_back("# Enable Extra RAM on GTA LCS and VCS\n");
     custom_config.push_back("ULUS10041 ULUS10160 ULES00151 ULES00502, highmem, on\n");
-    custom_config.push_back("# AC Bloodlines crashes with extra RAM\n");
-    custom_config.push_back("ULES01367, highmem, off\n");
 
     saveSettings();
     

--- a/extras/menus/arkMenu/include/ark_settings.h
+++ b/extras/menus/arkMenu/include/ark_settings.h
@@ -856,6 +856,10 @@ void resetSettings() {
     custom_config.push_back("\n");
     custom_config.push_back("# Luxor doesn't like Inferno Cache\n");
     custom_config.push_back("ULUS10201, infernocache, off\n");
+    custom_config.push_back("# Enable Extra RAM on GTA LCS and VCS\n");
+    custom_config.push_back("ULUS10041 ULUS10160 ULES00151 ULES00502, highmem, on\n");
+    custom_config.push_back("# AC Bloodlines crashes with extra RAM\n");
+    custom_config.push_back("ULES01367, highmem, off\n");
 
     saveSettings();
     

--- a/extras/menus/vshmenu/config.c
+++ b/extras/menus/vshmenu/config.c
@@ -200,7 +200,11 @@ void reset_ark_settings(vsh_Menu *vsh){
     	"always, noanalog, off\n"
     	"always, qaflags, on\n"
     	"# Luxor doesn't like Inferno Cache\n"
-    	"ULUS10201, infernocache, off";
+    	"ULUS10201, infernocache, off\n"
+    	"# Enable Extra RAM on GTA LCS and VCS\n"
+    	"ULUS10041 ULUS10160 ULES00151 ULES00502, highmem, on\n"
+    	"# AC Bloodlines crashes with extra RAM\n"
+    	"ULES01367, highmem, off\n";
 
     char arkMenuPath[ARK_PATH_SIZE];
     char arkSettingsPath[ARK_PATH_SIZE];

--- a/extras/menus/vshmenu/config.c
+++ b/extras/menus/vshmenu/config.c
@@ -202,9 +202,7 @@ void reset_ark_settings(vsh_Menu *vsh){
     	"# Luxor doesn't like Inferno Cache\n"
     	"ULUS10201, infernocache, off\n"
     	"# Enable Extra RAM on GTA LCS and VCS\n"
-    	"ULUS10041 ULUS10160 ULES00151 ULES00502, highmem, on\n"
-    	"# AC Bloodlines crashes with extra RAM\n"
-    	"ULES01367, highmem, off\n";
+    	"ULUS10041 ULUS10160 ULES00151 ULES00502, highmem, on\n";
 
     char arkMenuPath[ARK_PATH_SIZE];
     char arkSettingsPath[ARK_PATH_SIZE];


### PR DESCRIPTION
Found it crashing with highmemory enabled. You can check it yourself if you like: https://psproms.io/assassins-creed-bloodlines-psp-rom-iso/