### PR TITLE
Add FlatOut - Head On, an exception of the Inferno Driver

### DIFF
--- a/contrib/SETTINGS.TXT
+++ b/contrib/SETTINGS.TXT
@@ -20,5 +20,9 @@ always, qaflags, on
 # Luxor doesn't like Inferno Cache
 ULUS10201, infernocache, off
 
+# Flat-out doesn't like Inferno Cache
+ULES00968, infernocache, off
+ULUS10328, infernocache, off
+
 # Enable Extra RAM on GTA LCS and VCS
 ULUS10041 ULUS10160 ULES00151 ULES00502, highmem, on


### PR DESCRIPTION
While running with the Inferno driver, it will result in a stuck loading screen, after any types of events in game (Race, Derby, Stunt). The loading screen will display a complete progress bar, and will continue using the Memory Stick excessively despite the lack of any progress past this screen. Quitting via the Home button will soft-lock your device until you hard-reset it.
https://reddit.com/r/PSP/comments/ec1tz2/finally_figured_out_why_flatout_head_on_kept

I can confirm this issue on my PSP 1K, but haven't tried other models, nor on a PSP Vita currently.

Source for the two game IDs. https://serialstation.com/games/91b28a96-64b8-4842-83fd-6e1d79ad9677