### PR TITLE
Fix deadlock in customlauncher

### DIFF
--- a/extras/menus/arkMenu/include/entry.h
+++ b/extras/menus/arkMenu/include/entry.h
@@ -114,7 +114,7 @@ class Entry{
         void drawBG();
         
         bool pmfPrompt();
-        void execute();
+        void execute(bool isAutoboot = false);
         
         virtual char* getType()=0;
         virtual char* getSubtype()=0;

--- a/extras/menus/arkMenu/main.cpp
+++ b/extras/menus/arkMenu/main.cpp
@@ -66,11 +66,11 @@ int main(int argc, char** argv){
         const char* last_game = common::getConf()->last_game;
         if (Eboot::isEboot(last_game)){
             Eboot* eboot = new Eboot(last_game);
-            eboot->execute();
+            eboot->execute(true);
         }
         else if (Iso::isISO(last_game)){
             Iso* iso = new Iso(last_game);
-            iso->execute();
+            iso->execute(true);
         }
     }
 

--- a/extras/menus/arkMenu/src/entry.cpp
+++ b/extras/menus/arkMenu/src/entry.cpp
@@ -108,13 +108,15 @@ void Entry::freeIcon(){
         delete aux;
 }
 
-void Entry::execute(){
-    char* last_game = common::getConf()->last_game;
-    if (strcmp(last_game, this->path.c_str()) != 0 && name != "UMD Drive" && name != "Recovery Menu"){
-        strcpy(last_game, this->path.c_str());
+void Entry::execute(bool isAutoboot){
+    if (!isAutoboot) {
+        char* last_game = common::getConf()->last_game;
+        if (strcmp(last_game, this->path.c_str()) != 0 && name != "UMD Drive" && name != "Recovery Menu"){
+            strcpy(last_game, this->path.c_str());
+        }
+        common::saveConf();
+        this->gameBoot();
     }
-    common::saveConf();
-    this->gameBoot();
     this->doExecute();
 }
 


### PR DESCRIPTION
The freezing was caused by common::saveConf(); but there is no point in saving the config if nothing has changed as you are autobooting.
The adding of the parameter allows you to keep the autoboot early in the loading and shave off some ms0 readings instead of having to move it after the menu initialization like discussed on discord.