### PR TITLE
Fix FileExistsError on Windows when using 1.50 Kernel Addon

### DIFF
--- a/contrib/PC/MagicMemoryCreator/main.py
+++ b/contrib/PC/MagicMemoryCreator/main.py
@@ -267,7 +267,11 @@ def run() -> None:
                 shutil.copytree("150\\F0\\", "TM\\DCARK\\150\\", dirs_exist_ok=True)
                 shutil.copytree("150\\F1\\", "TM\\DCARK\\150\\", dirs_exist_ok=True)
                 os.makedirs("TM\\DCARK\\150\\registry", exist_ok=True)
-                os.rename("TM\\DCARK\\150\\kd\\pspbtknf_game.txt", "TM\\DCARK\\150\\kd\\pspbtcnf_game.txt")
+                try:
+                    os.rename("TM\\DCARK\\150\\kd\\pspbtknf_game.txt", "TM\\DCARK\\150\\kd\\pspbtcnf_game.txt")
+                except:
+                    os.remove("TM\\DCARK\\150\\kd\\pspbtcnf_game.txt")
+                    os.rename("TM\\DCARK\\150\\kd\\pspbtknf_game.txt", "TM\\DCARK\\150\\kd\\pspbtcnf_game.txt")
 
         elif _150_kernel_addon.get() and local_150_filepath is not None:
             if ostype == 'Linux' or ostype == 'Darwin':
@@ -281,7 +285,11 @@ def run() -> None:
                 shutil.copytree("150\\F0\\", "TM\\DCARK\\150\\", dirs_exist_ok=True)
                 shutil.copytree("150\\F1\\", "TM\\DCARK\\150\\", dirs_exist_ok=True)
                 os.makedirs("TM\\DCARK\\150\\registry", exist_ok=True)
-                os.rename("TM\\DCARK\\150\\kd\\pspbtknf_game.txt", "TM\\DCARK\\150\\kd\\pspbtcnf_game.txt")
+                try:
+                    os.rename("TM\\DCARK\\150\\kd\\pspbtknf_game.txt", "TM\\DCARK\\150\\kd\\pspbtcnf_game.txt")
+                except:
+                    os.remove("TM\\DCARK\\150\\kd\\pspbtcnf_game.txt")
+                    os.rename("TM\\DCARK\\150\\kd\\pspbtknf_game.txt", "TM\\DCARK\\150\\kd\\pspbtcnf_game.txt")
 
     if ostype == 'Linux':
         disk = var.get() + '1'


### PR DESCRIPTION
On Windows, running this script with 1.50 Kernel Addon will throw an exception on line 270.
<img width="979" height="512" alt="Screenshot 2025-12-01 024457" src="https://github.com/user-attachments/assets/fe89d064-9240-4726-94d6-7f560463e45b" />
This commit is to fix this error by deleting the destination and trying again.